### PR TITLE
Fix edit mode for snippets

### DIFF
--- a/src/components/SnippetManager/SnippetManager.vue
+++ b/src/components/SnippetManager/SnippetManager.vue
@@ -28,6 +28,9 @@ function forwardDeleteSnippet(id: string) {
 }
 
 function onAddSnippet(adding: boolean) {
+  if (!adding) {
+    snippetToEdit.value = null;
+  }
   emit('toggle-add-snippet', adding);
 }
 


### PR DESCRIPTION
## Summary
- allow editing in NewSnippet form
- reset snippetToEdit when closing modal

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-import')*

------
https://chatgpt.com/codex/tasks/task_e_6841978d13a48323b18d2b87eb7b16b5